### PR TITLE
feat(terraform): add archtecture to example tfvars file

### DIFF
--- a/deploy-oke-using-ubuntu/terraform/README.md
+++ b/deploy-oke-using-ubuntu/terraform/README.md
@@ -51,6 +51,7 @@ ssh_private_key_path = "~/.ssh/id_rsa"
 
 # Optional
 public_nodes           = false
+architecture           = "amd64"
 add_managed_nodes      = false
 add_self_managed_nodes = false
 ```

--- a/deploy-oke-using-ubuntu/terraform/terraform.tfvars.example
+++ b/deploy-oke-using-ubuntu/terraform/terraform.tfvars.example
@@ -15,5 +15,6 @@ ssh_private_key_path = "~/.ssh/id_rsa"
 
 # Optional
 public_nodes           = false
+architecture           = "amd64"
 add_managed_nodes      = false
 add_self_managed_nodes = false


### PR DESCRIPTION
Architecture has a default already set but for clarity purposes in the [the guide](https://canonical-oracle.readthedocs-hosted.com/oracle-how-to/deploy-oke-nodes-using-ubuntu-images/).

This is because we provide `arm64` and `amd64` images which will obviously fail to boot if registered incorrectly or provided to the wrong instance type.